### PR TITLE
Added authorize_with_ssl_client

### DIFF
--- a/lib/smart_proxy_pulp_plugin/pulp_api.rb
+++ b/lib/smart_proxy_pulp_plugin/pulp_api.rb
@@ -4,6 +4,7 @@ require 'smart_proxy_pulp_plugin/pulp_client'
 module PulpProxy
   class Api < Sinatra::Base
     helpers ::Proxy::Helpers
+    authorize_with_ssl_client
 
     get "/status" do
       content_type :json


### PR DESCRIPTION
We have refactored develop proxy and extracted the SSL client cert handling
code. Please review. This is needed *only if* this plugin uses SSL client
certification verification. If not, please close it.